### PR TITLE
Fix ARM64 test

### DIFF
--- a/internal/system/system_arm64_test.go
+++ b/internal/system/system_arm64_test.go
@@ -13,7 +13,7 @@ func TestGetCpuArchitecture(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if cpuArch == "aarch64" {
+	if cpuArch != "aarch64" {
 		t.Error(cpuArch)
 	}
 }


### PR DESCRIPTION
This is very likely to be incorrect.

Also, I noticed that `make test-cpu-detection` is not included in GitHub Actions. There is only cross-compile. It might be better to add cross-platform tests to the workflow.