### PR TITLE
Use the geo.mirror.pkgbuild.com mirror

### DIFF
--- a/internal/api/submit/client_test.go
+++ b/internal/api/submit/client_test.go
@@ -27,7 +27,7 @@ func TestSendRequest(t *testing.T) {
 	request.Pacman.Packages = []string{"pacman", "linux"}
 	request.System.Architecture = "x86_64"
 	request.OS.Architecture = "i686"
-	request.Pacman.Mirror = "https://mirror.pkgbuild.com/"
+	request.Pacman.Mirror = "https://geo.mirror.pkgbuild.com/"
 	err := client.SendRequest(*request)
 
 	if err != nil {
@@ -68,7 +68,7 @@ func validateRequest(t *testing.T, req *http.Request) {
 	if request.OS.Architecture != "i686" {
 		t.Error("Invalid arch value")
 	}
-	if request.Pacman.Mirror != "https://mirror.pkgbuild.com/" {
+	if request.Pacman.Mirror != "https://geo.mirror.pkgbuild.com/" {
 		t.Error("Invalid mirror value")
 	}
 }
@@ -95,7 +95,7 @@ func TestSendRequestFollowsRedirect(t *testing.T) {
 	request.Pacman.Packages = []string{"pacman", "linux"}
 	request.System.Architecture = "x86_64"
 	request.OS.Architecture = "i686"
-	request.Pacman.Mirror = "https://mirror.pkgbuild.com/"
+	request.Pacman.Mirror = "https://geo.mirror.pkgbuild.com/"
 	err := client.SendRequest(*request)
 
 	if err != nil {

--- a/internal/pacman/pacman_test.go
+++ b/internal/pacman/pacman_test.go
@@ -19,7 +19,7 @@ func init() {
 
 	Mocks["pacman-conf"] = func() {
 		fmt.Println("https://mirror.rackspace.com/archlinux/core/os/x86_64")
-		fmt.Println("https://mirror.pkgbuild.com/core/os/x86_64")
+		fmt.Println("https://geo.mirror.pkgbuild.com/core/os/x86_64")
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
geo.mirror.pkgbuild.com is a GeoDNS mirror that points to sponsored mirrors.

This avoids the usage of Arch's infrastructure (mirror.pkgbuild.com) for large downloads. See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/522 for details.