### PR TITLE
Support LoongArch 64Bit

### DIFF
--- a/internal/system/system_linux_test.go
+++ b/internal/system/system_linux_test.go
@@ -23,6 +23,8 @@ func TestGetMachine(t *testing.T) {
 		expectedArch = "^aarch64$"
 	case "riscv64":
 		expectedArch = "^riscv64$"
+	case "loong64":
+		expectedArch = "^loongarch64$"
 	}
 
 	if err != nil {

--- a/internal/system/system_loong64.go
+++ b/internal/system/system_loong64.go
@@ -1,0 +1,5 @@
+package system
+
+func (system *System) GetCpuArchitecture() (string, error) {
+	return "loong64", nil
+}

--- a/internal/system/system_loong64_test.go
+++ b/internal/system/system_loong64_test.go
@@ -1,0 +1,18 @@
+package system
+
+import (
+	"testing"
+)
+
+func TestGetCpuArchitecture(t *testing.T) {
+	system := System{}
+
+	cpuArch, err := system.GetCpuArchitecture()
+
+	if err != nil {
+		t.Error(err)
+	}
+	if cpuArch != "loong64" {
+		t.Error(cpuArch)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -44,10 +44,11 @@ test-cross-platform:
 	CGO_ENABLED=0 GOARCH=arm64 go test -v -exec qemu-aarch64 ./...
 	CGO_ENABLED=0 GOARCH=riscv64 go test -v -exec qemu-riscv64 ./...
 	CGO_ENABLED=0 GOARCH=386 go test -v -exec 'qemu-x86_64 /usr/bin/linux32' ./...
+	CGO_ENABLED=0 GOARCH=loong64 go test -v -exec qemu-loongarch64 ./...
 
 # build for different CPU architectures
 test-build:
-	@for arch in amd64 386 arm64 arm riscv64; do \
+	@for arch in amd64 386 arm64 arm riscv64 loong64; do \
 		echo "Building for ${arch}"; \
 		CGO_ENABLED=0 GOARCH=${arch} go build -o tests/build/pkgstats-${arch}; \
 	done
@@ -70,6 +71,8 @@ test-cpu-detection:
 	if qemu-x86_64 -version | grep -Eq 'version [7-9]\.[2-9][0-9]*\.[0-9]+$'; then CGO_ENABLED=0 GOARCH=amd64 go run -exec 'qemu-x86_64 -cpu Haswell' main.go architecture system 2>&1 | grep -q '^x86_64_v3$'; fi
 	@# 32-Bit on x86_64
 	CGO_ENABLED=0 GOARCH=386 go run -exec 'qemu-x86_64 /usr/bin/linux32' main.go architecture system | grep -q '^x86_64'
+	@# loong64
+	CGO_ENABLED=0 GOARCH=loong64 go run -exec 'qemu-loongarch64 -cpu la464-loongarch-cpu' main.go architecture system | grep -q '^loong64$'
 
 # test os architecture detection on different CPUs
 test-os-detection:
@@ -83,6 +86,8 @@ test-os-detection:
 	CGO_ENABLED=0 GOARCH=amd64 go run -exec 'qemu-x86_64' main.go architecture os | grep -q '^x86_64$'
 	@# 32-Bit on x86_64
 	CGO_ENABLED=0 GOARCH=386 go run -exec 'qemu-x86_64 /usr/bin/linux32' main.go architecture os | grep -q '^i686$'
+	@# loong64
+	CGO_ENABLED=0 GOARCH=loong64 go run -exec 'qemu-loongarch64' main.go architecture os| grep -q '^loongarch64$'
 
 # run integration tests with a mocked API server
 test-integration:


### PR DESCRIPTION
archlinux for loongarch64 is here: https://github.com/loongarchlinux


$ just test-build test-cpu-detection   test-cross-platform  test-os-detection 2>&1 | tee [test.log](https://github.com/archlinux-de/pkgstats-cli/files/11595278/test.log)
