### PR TITLE
Add systemd timer install target

### DIFF
--- a/init/pkgstats.timer
+++ b/init/pkgstats.timer
@@ -8,4 +8,4 @@ RandomizedDelaySec=7d
 Persistent=true
 
 [Install]
-WantedBy=default.target
+WantedBy=timers.target


### PR DESCRIPTION
Systemd complains about a missing installation config when trying to enable the timer. Adding a default target fixes this.

```
$ systemctl enable pkgstats.timer
The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=,
Also=, or Alias= settings in the [Install] section, and DefaultInstance= for
template units). This means they are not meant to be enabled or disabled using systemctl.
 
Possible reasons for having these kinds of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/, .requires/, or .upholds/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
```