### PR TITLE
Fix pkgstats.timer

### DIFF
--- a/init/pkgstats.timer
+++ b/init/pkgstats.timer
@@ -3,6 +3,5 @@ Description=Weekly pkgstats submission
 
 [Timer]
 OnCalendar=weekly
-AccuracySec=1d
-RandomizedDelaySec=7d
+RandomizedOffsetSec=1 week
 Persistent=true


### PR DESCRIPTION
The current timer file is faulty and the systemd timer does not fire at all if the computer is restarted daily. This problem is also described here: https://github.com/systemd/systemd/issues/21166

 The correct way to configure the timer is `RandomizedOffsetSec=` (see [`man systemd.timer`](https://www.man7.org/linux/man-pages/man5/systemd.timer.5.html))